### PR TITLE
ニュースレター作成時のロジックを変更

### DIFF
--- a/app/controllers/admin/news_letter_controller.rb
+++ b/app/controllers/admin/news_letter_controller.rb
@@ -11,7 +11,7 @@ class Admin::NewsLetterController < Admin::AdminController
         where('send_to = ?', 'participant').first
 
     @news_letter = NewsLetter.
-        where('distribution <= ? AND is_save = ? AND is_sent = ?', Time.now, false, false).
+        where('distribution >= ? AND is_save = ? AND is_sent = ?', Time.now, false, false).
         where('is_monthly = ? ', false).
         where('send_to = ?', 'family').first
 
@@ -27,7 +27,7 @@ class Admin::NewsLetterController < Admin::AdminController
 
   def create
     @news_letter = NewsLetter.new(news_letter_params)
-    set_right_time
+    @news_letter.is_monthly ? set_as_next_month : set_right_time
 
     respond_to do |format|
       if @news_letter.save
@@ -79,6 +79,10 @@ class Admin::NewsLetterController < Admin::AdminController
       Time.zone = "Asia/Tokyo"
       @news_letter.distribution = Time.zone.parse(news_letter_params[:distribution]).utc
     end
+  end
+
+  def set_as_next_month
+    @news_letter.distribution = Time.zone.parse(Time.now.next_month.beginning_of_month.strftime("%Y/%m/%d")).utc
   end
 
   def news_letter_params

--- a/app/models/news_letter.rb
+++ b/app/models/news_letter.rb
@@ -45,6 +45,7 @@ class NewsLetter < ApplicationRecord
     news_letter = NewsLetter.
         where('is_save = ?', false).
         where('is_monthly = ? ', true).
+        where('distribution <= ?', Time.now).
         where('send_to = ?', 'participant').first
     # nil check
     return if news_letter.nil?
@@ -63,8 +64,13 @@ class NewsLetter < ApplicationRecord
     # メールを送信する
     NewsLetterMailer.send_news_letter(news_letter, bcc_address).deliver_now
 
+    # 配信予定日を翌月にする。
     # 送信済みにする
-    news_letter.update(is_sent: true)
+    news_letter.update(
+        is_sent: true,
+        distribution: news_letter.distribution.next_month
+    )
+
   end
 
 

--- a/app/views/admin/news_letter/index.html.erb
+++ b/app/views/admin/news_letter/index.html.erb
@@ -18,7 +18,7 @@
           <tbody>
           <tr>
             <td><%= @monthly_news_letter.subject %></td>
-            <td><%= Time.now.next_month.beginning_of_month.strftime('%m月%d日') %></td>
+            <td><%= @monthly_news_letter.distribution.strftime('%m月%d日') %></td>
             <td><%= link_to '詳細', admin_news_letter_path(@monthly_news_letter) %></td>
             <td><%= link_to '編集', edit_admin_news_letter_path(@monthly_news_letter) %></td>
           </tr>


### PR DESCRIPTION
参加者向けの月１メールであれば、来月の頭を送信日時に設定し、
スケジューラーによる送信後に、翌月を送信日時に更新する。(6631dad)

index に出すメールのロジックを正しく変更。 (6050beb)
 - app/controllers/admin/news_letter_controller.rb