### PR TITLE
🔊 add log

### DIFF
--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -11,6 +11,11 @@ task three_days_reminder_task: :environment do
       end
     end
   end
+  Raven.capture_message(
+    'Run three_days_before',
+    level: :debug,
+    extra: { study_abroads: study_abroads }
+  )
   puts 'done.'
 end
 
@@ -22,6 +27,11 @@ task seven_days_over_task: :environment do
     CommonMailer.readjustment_to_candidate(study_abroad).deliver_now
     CommonMailer.readjustment_to_manma(study_abroad).deliver_now
   end
+  Raven.capture_message(
+    'Run serven_days_over',
+    level: :debug,
+    extra: { study_abroads: study_abroads }
+  )
   puts 'done.'
 end
 

--- a/spec/models/study_abroad_spec.rb
+++ b/spec/models/study_abroad_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe StudyAbroad, type: :model do
   end
 
   describe 'self.all_three_days_before_for_remind' do
-    it '正常系EventDateが存在する場合、StudyAbroadが取得できないこと' do
+    it '正常系: EventDateが存在する場合、StudyAbroadが取得できないこと' do
       given = FactoryBot.create(:study_abroad, created_at: 3.days.ago)
       user = FactoryBot.create(:user)
       FactoryBot.create(:event_date, user: user, study_abroad: given)
@@ -147,6 +147,14 @@ RSpec.describe StudyAbroad, type: :model do
       FactoryBot.create(:study_abroad, created_at: 8.days.ago)
       expected = described_class.all_seven_days_before_for_remind
       expect(expected).to eq []
+    end
+
+    it '7日前の情報が取得できること' do
+      study_abroad = FactoryBot.create(:study_abroad, created_at: Time.utc(2020, 6, 23, 2, 27, 6))
+      travel_to Time.utc(2020, 6, 30, 11, 0, 0) do
+        expected = described_class.all_seven_days_before_for_remind
+        expect(expected).to eq [study_abroad]
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   # devise
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view


### PR DESCRIPTION
#290 

メール送信されないと報告が来ているが、テストをしてみたところロジックに問題はなさそう。

Heroku Schedulerが正しく実行されていることと期待するデータが取得できていることを確認するためログを仕込む。
正しく取得できている場合、メール関係の不具合の可能性も鑑みる