### PR TITLE
家庭情報の削除対応

### DIFF
--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -44,7 +44,6 @@ class Admin::LocationsController < Admin::AdminController
   private
 
   def family_params
-    family = Location.all
-    family.includes(user: [:location, :contact, { study_abroad_request: { study_abroad: :email_queue } }])
+    Location.joins(:user).includes(user: [:location, :contact, { study_abroad_request: { study_abroad: :email_queue } }])
   end
 end

--- a/app/services/google/spread_sheet_fetch_service.rb
+++ b/app/services/google/spread_sheet_fetch_service.rb
@@ -23,7 +23,7 @@ module Google
       # 家庭情報スプレッドシートID
       spreadsheet_id = ENV['SPREAD_SHEET_ID']
       sheet_name = 'フォームの回答 1'
-      range = "#{sheet_name}!A2:AR"
+      range = "#{sheet_name}!A2:AS"
       response = service.get_spreadsheet_values(spreadsheet_id, range)
       puts 'No data found.' if response.values.empty?
 

--- a/app/services/google/spread_sheet_store_service.rb
+++ b/app/services/google/spread_sheet_store_service.rb
@@ -20,8 +20,21 @@ module Google
           gender: 0, # フォームに存在しない情報
           is_family: true
         }
-        user = User.find_or_initialize_by(spread_sheets_timestamp: r[Settings.sheet.timestamp])
+        user = User.with_deleted.find_or_initialize_by(spread_sheets_timestamp: r[Settings.sheet.timestamp])
         user.update(user_query)
+        if !user.deleted_at && r[Settings.sheet.deleted].to_s == '1'
+          if user.destroy
+            Rails.logger.info "ユーザーID：#{user.id}を削除しました。"
+          else
+            Rails.logger.info "ユーザーID：#{user.id}を削除できませんでした。"
+          end
+        elsif user.deleted_at && r[Settings.sheet.deleted].to_s != '1'
+          if user.restore
+            Rails.logger.info "ユーザーID：#{user.id}を復活しました。"
+          else
+            Rails.logger.info "ユーザーID：#{user.id}を復活できませんでした。"
+          end
+        end
 
         # 連絡先情報のパース
         contact_query = {

--- a/config/application.yml
+++ b/config/application.yml
@@ -19,6 +19,7 @@ defaults: &defaults
     phone_number: 4
     latitude: 42
     longitude: 43
+    deleted: 44
   job_style:
     # none: 指定なし
     # both: 共働き


### PR DESCRIPTION
受け入れ家庭スプレッドシートの削除フラグの入力状況により削除、復活ができるように修正
・１を入力し、家庭情報取り込みを行うと削除
・１を消して、家庭情報取り込みを行うと復活
・フラグに変更がない場合は情報の更新処理のみ